### PR TITLE
feat: Force UTC spark session timezone

### DIFF
--- a/dtml/dbx/pysparktesting/spark_base.py
+++ b/dtml/dbx/pysparktesting/spark_base.py
@@ -54,6 +54,7 @@ def spark_base(metastore_dir: str) -> Iterator[SparkSession]:
             'spark.sql.catalog.spark_catalog',
             'org.apache.spark.sql.delta.catalog.DeltaCatalog',
         )
+        .config('spark.sql.session.timeZone', 'UTC')
     )
 
     # Create spark context


### PR DESCRIPTION
This matches default Databricks setting and prevents issues with timestamps being converted to the local timezone.