### PR TITLE
fix: clear old SparkSession before new creation

### DIFF
--- a/pysparkdt/spark_base.py
+++ b/pysparkdt/spark_base.py
@@ -7,10 +7,13 @@ from pyspark.sql import SparkSession
 
 def spark_base(metastore_dir: str) -> Iterator[SparkSession]:
     """Creates and yields a Spark session configured for local run with
-    dynamically created local metastore acting as the Dababricks data catalog.
+    dynamically created local metastore acting as the Databricks data catalog.
 
     It ensures proper teardown by stopping  the session and resetting the
     SparkContext gateway and JVM by being generator.
+
+    Only 1 session can be active at the time (previous session will be
+    stopped).
 
     Intended to be used as a pytest fixture, e.g.
 
@@ -37,6 +40,14 @@ def spark_base(metastore_dir: str) -> Iterator[SparkSession]:
     def spark():
         yield from spark_base(METASTORE_DIR)
     """
+    existing = SparkSession.getActiveSession()
+    if existing:
+        # Stop the Spark session and reset the gateway and JVM (otherwise
+        # metastore location could be incorrectly re-used)
+        existing.stop()
+        SparkContext._gateway = None
+        SparkContext._jvm = None
+
     #  Create a spark session with Delta
     builder = (
         SparkSession.builder.appName('test_app')
@@ -62,8 +73,7 @@ def spark_base(metastore_dir: str) -> Iterator[SparkSession]:
     session.sparkContext.setLogLevel('ERROR')
     yield session
 
-    # Teardown: Stop the Spark session and reset the gateway and JVM (otherwise
-    # metastore location would be incorrectly re-used by all tests)
+    # Teardown: Stop the Spark session and reset the gateway and JVM
     session.stop()
     SparkContext._gateway = None
     SparkContext._jvm = None


### PR DESCRIPTION
Fixes a bug that caused a SparkException when multiple modules each initialized their own Spark sessions. The original teardown, performed after the generator’s yield, did not run immediately after module tests finished.