### PR TITLE
chore: drop pyspark <4.0.0 support

### DIFF
--- a/.github/workflows/dynamic_workflow.yaml
+++ b/.github/workflows/dynamic_workflow.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        pyspark-version: ["3.5.5", "4.0.1"]
+        pyspark-version: ["4.0.1"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -597,4 +597,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.15"
-content-hash = "a62502f9d701fd01a51d1e2e53a431e5668e33fe651696a1c3ee613f5100f4af"
+content-hash = "ac61578f6eef193495b03fa7176e3c455c1010840117844dff5c269aadc5bb5d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -597,4 +597,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.15"
-content-hash = "ac61578f6eef193495b03fa7176e3c455c1010840117844dff5c269aadc5bb5d"
+content-hash = "e77a61a0b966b7df3bdfd099973d80f4126c57a1d5b0bf2f8f48639edd34e64e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ priority = "primary"
 
 [tool.poetry.dependencies]
 python = ">=3.10, <3.15"
-pyspark = { version = ">=3.5.0, !=3.5.6, !=3.5.7, !=3.5.8, !=3.5.9, !=3.5.10, !=3.5.11, <4.1.0", extras = ["sql"] }  # 3.5.6+ https://github.com/delta-io/delta/issues/4671 not solved for at least 3.5.6 - 3.5.8, we must use != to exclude versions as there is no conditional operator supported in pypi
-delta-spark = ">=3.0.0, <4.1.0"
+pyspark = { version = ">=4.0.0, <4.1.0", extras = ["sql"] }
+delta-spark = ">=4.0.0, <4.1.0"
 numpy = ">=1.26.0"
 pandas = "<3.0.0"  # PySpark 4.0.x not compatible with Pandas 3.0.x (30.1.2026) + Python 3.10 not compatible with Pandas 3
 setuptools = { version = "^75.6.0", python = ">=3.12" }  # Necessary for Python 3.12+ as distutils is missing without it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ priority = "primary"
 [tool.poetry.dependencies]
 python = ">=3.10, <3.15"
 pyspark = { version = ">=4.0.0, <4.1.0", extras = ["sql"] }
-delta-spark = ">=4.0.0, <4.1.0"
+delta-spark = ">=3.0.0, <4.1.0"
 numpy = ">=1.26.0"
 pandas = "<3.0.0"  # PySpark 4.0.x not compatible with Pandas 3.0.x (30.1.2026) + Python 3.10 not compatible with Pandas 3
 setuptools = { version = "^75.6.0", python = ">=3.12" }  # Necessary for Python 3.12+ as distutils is missing without it


### PR DESCRIPTION
PySpark 3.5.x support has been accumulating maintenance cost — see the !=3.5.6…!=3.5.11 exclusion list in pyproject.toml and the doubled CI matrix. Drop it now so we're aligned on one Spark major (4.x), matching the delta-spark 4 line.

This change also unblocks features depending on PySpark 4 cloudpickle behavior (see e.g. #23).