### PR TITLE
ci: always run poetry install after venv cache restore

### DIFF
--- a/.github/workflows/dynamic_workflow.yaml
+++ b/.github/workflows/dynamic_workflow.yaml
@@ -50,7 +50,6 @@ jobs:
           key: poetry-${{ matrix.python-version }}-pyspark-${{ matrix.pyspark-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
-        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
           poetry env use ${{ matrix.python-version }}
           poetry install


### PR DESCRIPTION
Skipping install on cache hit left CI with a broken .venv where dev tools like ruff were missing after Poetry recreated the environment.

Broken run: https://github.com/datamole-ai/pysparkdt/actions/runs/27824972782